### PR TITLE
Migrate Trix S3 uploads from Signature V2 to Signature V4

### DIFF
--- a/app/assets/javascripts/lib/trix_uploader.js
+++ b/app/assets/javascripts/lib/trix_uploader.js
@@ -9,14 +9,15 @@ TrixAttachment = function(element) {
 TrixAttachment.prototype.upload = function(attachment) {
   var form = new FormData
   var key = this.config.key + Math.random().toString().substr(2, 6) + "/" + attachment.file.name
+  var fields = this.config.fields || {}
+
   form.append("key", key)
-  form.append("AWSAccessKeyId", this.config.AWSAccessKeyId)
-  form.append("policy", this.config.policy)
-  form.append("signature", this.config.signature)
-  form.append("acl", this.config.acl)
+  Object.keys(fields).forEach(function(field) {
+    if (field !== "key") form.append(field, fields[field])
+  })
   form.append("file", attachment.file);
   var xhr = new XMLHttpRequest;
-  xhr.open("POST", this.config.host, true);
+  xhr.open("POST", this.config.upload_host || this.config.host, true);
 
   xhr.upload.onprogress = function(event) {
     if (event.total > 0)
@@ -32,4 +33,3 @@ TrixAttachment.prototype.upload = function(attachment) {
 
   return xhr.send(form);
 }
-

--- a/app/helpers/trix_editor_helper.rb
+++ b/app/helpers/trix_editor_helper.rb
@@ -1,7 +1,3 @@
-require "base64"
-require "openssl"
-require "digest/sha1"
-
 module TrixEditorHelper
   def trix_editor_tag(options)
     @trix_editor = true
@@ -19,31 +15,24 @@ module TrixEditorHelper
     end
   end
 
-  def trix_editor_attachment_signature_base64(path)
-    policy = trix_editor_attachment_policy_base64(path)
-    signature = OpenSSL::HMAC.digest(OpenSSL::Digest.new("sha1"), AwsFileStorage::AWS_BUCKET_URL.password, policy)
-    Base64.encode64(signature).delete("\n")
-  end
-
-  def trix_editor_attachment_policy_base64(path)
-    Base64.encode64({
-      expiration: 1.day.from_now.utc.iso8601,
-      conditions: [
-        {bucket: AwsFileStorage::BUCKET_NAME},
-        ["starts-with", "$key", path],
-        ["content-length-range", 0, 20.megabytes],
-        {acl: "public-read"}
-      ]
-    }.to_json).delete("\n")
+  def trix_editor_attachment_presigned_post(path)
+    Aws::S3::Resource.new.bucket(AwsFileStorage::BUCKET_NAME).presigned_post(
+      key_starts_with: path,
+      acl: "public-read",
+      success_action_status: "204",
+      content_length_range: 0..20.megabytes,
+      expires: 1.day.from_now
+    )
   end
 
   def trix_editor_attachment_config(path)
+    presigned_post = trix_editor_attachment_presigned_post(path)
+    public_host = File.join(AwsFileStorage::BUCKET_URL, "")
+
     {
-      host: File.join(AwsFileStorage::BUCKET_URL, ""),
-      AWSAccessKeyId: AwsFileStorage::AWS_BUCKET_URL.user,
-      policy: trix_editor_attachment_policy_base64(path),
-      signature: trix_editor_attachment_signature_base64(path),
-      acl: "public-read",
+      upload_host: public_host,
+      host: public_host,
+      fields: presigned_post.fields,
       key: path
     }
   end

--- a/test/helpers/trix_editor_helper_test.rb
+++ b/test/helpers/trix_editor_helper_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class TrixEditorHelperTest < ActiveSupport::TestCase
+  include TrixEditorHelper
+
+  def test_attachment_config_uses_sigv4_presigned_post_fields
+    config = trix_editor_attachment_config("development/skills/attachments/123/")
+
+    assert_equal(File.join(AwsFileStorage::BUCKET_URL, ""), config[:host])
+    assert_equal(config[:host], config[:upload_host])
+    assert_equal("public-read", config[:fields]["acl"])
+    assert_equal("204", config[:fields]["success_action_status"])
+    assert_equal("AWS4-HMAC-SHA256", config[:fields]["x-amz-algorithm"])
+    assert_match(%r{\A#{Regexp.escape(AwsFileStorage::AWS_BUCKET_URL.user)}/\d{8}/#{Regexp.escape(AwsFileStorage::BUCKET_REGION)}/s3/aws4_request\z}, config[:fields]["x-amz-credential"])
+    assert_match(/\A\d{8}T\d{6}Z\z/, config[:fields]["x-amz-date"])
+    assert_match(/\A\h{64}\z/, config[:fields]["x-amz-signature"])
+    assert_nil(config[:fields]["AWSAccessKeyId"])
+    assert_nil(config[:fields]["signature"])
+  end
+
+  def test_attachment_config_policy_allows_key_prefix_and_upload_size
+    config = trix_editor_attachment_config("development/skills/attachments/123/")
+    policy = JSON.parse(Base64.decode64(config[:fields]["policy"]))
+
+    assert(policy["conditions"].include?({"bucket" => AwsFileStorage::BUCKET_NAME}))
+    assert(policy["conditions"].include?(["starts-with", "$key", "development/skills/attachments/123/"]))
+    assert(policy["conditions"].include?(["content-length-range", 0, 20.megabytes]))
+  end
+end


### PR DESCRIPTION
This PR updates browser-based Trix attachment uploads to use AWS Signature Version 4 instead of the legacy Signature Version 2 form fields.

Before this change, the app generated old-style S3 POST parameters such as:
- `AWSAccessKeyId`
- `policy`
- `signature`

That flow is not supported uniformly across AWS regions. In particular, newer or stricter regions require SigV4. A concrete example is Frankfurt (`eu-central-1`): direct uploads there fail with:

`The authorization mechanism you have provided is not supported. Please use AWS4-HMAC-SHA256.`

With this change, Trix uploads now use a SigV4-compatible presigned POST generated by the AWS SDK, so the browser submits fields such as:
- `x-amz-algorithm`
- `x-amz-credential`
- `x-amz-date`
- `x-amz-signature`

**Why**

The current V2 upload flow works in some older regions, but it is not portable across AWS. That blocks using regions such as Frankfurt (`eu-central-1`) for development or deployment. Migrating to SigV4 removes that regional limitation and aligns the upload path with current AWS expectations.

**What changed**

- replaced legacy Trix S3 POST signing with AWS SDK SigV4 presigned POST generation
- updated the Trix uploader JS to submit generic presigned form fields instead of hardcoded V2 fields
- kept the existing attachment key/path behavior
- added regression coverage for the generated SigV4 fields

**Impact**

- browser-based attachment uploads now work in SigV4-only regions
- no change to the persisted attachment path structure
- brings the Trix upload path in line with modern AWS S3 requirements
